### PR TITLE
get loc from path.node before it is replace

### DIFF
--- a/src/macroHelpers.js
+++ b/src/macroHelpers.js
@@ -208,9 +208,9 @@ function parseTte({ path, types: t, styledIdentifier, state }) {
 }
 
 function replaceWithLocation(path, replacement) {
+  const { loc } = path.node
   const newPaths = replacement ? path.replaceWith(replacement) : []
   if (Array.isArray(newPaths) && newPaths.length > 0) {
-    const { loc } = path.node
     newPaths.forEach(p => {
       p.node.loc = loc
     })


### PR DESCRIPTION
Prior to this change, when paired with the `@linaria` babel preset, it would result in the following error

```
TypeError: <root>/packages/components/src/playground/button.tsx: Cannot destructure property 'end' of 'ex.node.loc' as it is undefined.
```
source: https://github.com/callstack/linaria/issues/679#issuecomment-742125558

It seems that this loc is removed when the node is replaced and so it's being set to undefined.

Unfortunately I don't know what tests to add that would catch this issue since it's making use of the `babel-plugin-tester` package which already produces all green test results.